### PR TITLE
feat: Implement Dynamic Leaderboards (Classes vs Students)

### DIFF
--- a/frontend/src/pages/Analytics.jsx
+++ b/frontend/src/pages/Analytics.jsx
@@ -51,16 +51,28 @@ const SUBJECT_STATS_MAP = {
   '5': { attendance: 82, avgLate: 6, riskCount: 9, lateTime: '09:08 AM' }, // English
 };
 
-const CLASS_PERFORMANCE = [
+const GLOBAL_LEADERBOARD_BEST = [
   { name: 'Grade 9A', score: 91 },
   { name: 'Grade 10A', score: 88 },
   { name: 'Grade 8C', score: 86 },
 ];
 
-const CLASS_RISK = [
+const GLOBAL_LEADERBOARD_RISK = [
   { name: 'Grade 11C', score: 71 },
   { name: 'Grade 12B', score: 68 },
   { name: 'Grade 7D', score: 73 },
+];
+
+const STUDENT_LEADERBOARD_BEST = [
+  { name: 'Rahul Kumar', score: 98 },
+  { name: 'Anjali Singh', score: 96 },
+  { name: 'Vikram Patel', score: 95 },
+];
+
+const STUDENT_LEADERBOARD_RISK = [
+  { name: 'Rohan Gupta', score: 65 },
+  { name: 'Priya Sharma', score: 68 },
+  { name: 'Amit Verma', score: 70 },
 ];
 
 const CLASS_BREAKDOWN = [
@@ -119,6 +131,9 @@ export default function Analytics() {
   // Logic for dynamic stats based on selection
   const isGlobal = selectedSubject === 'all';
   const stats = isGlobal ? GLOBAL_STATS : (SUBJECT_STATS_MAP[selectedSubject] || GLOBAL_STATS);
+
+  const bestPerforming = isGlobal ? GLOBAL_LEADERBOARD_BEST : STUDENT_LEADERBOARD_BEST;
+  const needingSupport = isGlobal ? GLOBAL_LEADERBOARD_RISK : STUDENT_LEADERBOARD_RISK;
 
   return (
     <div className="min-h-screen bg-[var(--bg-primary)] p-6 md:p-8">
@@ -309,10 +324,10 @@ export default function Analytics() {
               </div>
             </div>
             {/* Best Performing List */}
-            <div className="bg-[var(--bg-card)] p-5 rounded-xl border border-[var(--border-color)] shadow-sm">
+            <div className="bg-[var(--bg-card)] p-5 rounded-xl border border-[var(--border-color)] shadow-sm" data-testid="best-performing-list">
               <h3 className="font-semibold text-sm text-[var(--text-main)] mb-3">{t('analytics.lists.best')}</h3>
               <div className="space-y-3">
-                {CLASS_PERFORMANCE.map((c, i) => (
+                {bestPerforming.map((c, i) => (
                   <div key={i} className="flex items-center justify-between text-sm">
                       <div className="flex items-center gap-3">
                         <div className="w-5 h-5 rounded-full bg-[var(--primary)]/10 text-[var(--primary)] flex items-center justify-center text-[10px] font-bold">{i+1}</div>
@@ -324,10 +339,10 @@ export default function Analytics() {
               </div>
             </div>
              {/* Needs Support List */}
-             <div className="bg-[var(--bg-card)] p-5 rounded-xl border border-[var(--border-color)] shadow-sm">
+             <div className="bg-[var(--bg-card)] p-5 rounded-xl border border-[var(--border-color)] shadow-sm" data-testid="needing-support-list">
               <h3 className="font-semibold text-sm text-[var(--text-main)] mb-3">{t('analytics.lists.needs_support')}</h3>
               <div className="space-y-3">
-                {CLASS_RISK.map((c, i) => (
+                {needingSupport.map((c, i) => (
                   <div key={i} className="flex items-center justify-between text-sm">
                       <div className="flex items-center gap-3">
                         <div className="w-5 h-5 rounded-full bg-[var(--primary)]/10 text-[var(--primary)] flex items-center justify-center text-[10px] font-bold">{i+1}</div>

--- a/frontend/src/pages/__tests__/Analytics.test.jsx
+++ b/frontend/src/pages/__tests__/Analytics.test.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Analytics from '../Analytics';
+
+// Mock Recharts to avoid rendering complexities
+vi.mock('recharts', () => {
+  const Original = vi.importActual('recharts');
+  return {
+    ...Original,
+    ResponsiveContainer: ({ children }) => <div data-testid="chart-container">{children}</div>,
+    AreaChart: () => <div data-testid="area-chart">AreaChart</div>,
+    Area: () => <div />,
+    XAxis: () => <div />,
+    YAxis: () => <div />,
+    CartesianGrid: () => <div />,
+    Tooltip: () => <div />,
+    PieChart: () => <div data-testid="pie-chart">PieChart</div>,
+    Pie: () => <div />,
+    Cell: () => <div />,
+  };
+});
+
+describe('Analytics Page', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('renders global leaderboard (classes) by default', () => {
+        render(<Analytics />);
+        
+        const bestList = screen.getByTestId('best-performing-list');
+        const supportList = screen.getByTestId('needing-support-list');
+
+        // Check for Class Names used in Global Leaderboard
+        expect(within(bestList).getByText('Grade 9A')).toBeInTheDocument();
+        expect(within(bestList).getByText('Grade 10A')).toBeInTheDocument();
+        
+        // Check Needs Support list
+        expect(within(supportList).getByText('Grade 11C')).toBeInTheDocument();
+
+        // Ensure student names are NOT present in the lists
+        expect(within(bestList).queryByText('Rahul Kumar')).not.toBeInTheDocument();
+    });
+
+    it('renders student leaderboard when a subject is selected', async () => {
+        render(<Analytics />);
+
+        // Find the select dropdown
+        const select = screen.getByRole('combobox');
+        
+        // Change selection to a subject (e.g., Math with id '1')
+        fireEvent.change(select, { target: { value: '1' } });
+        
+        const bestList = screen.getByTestId('best-performing-list');
+
+        // Wait for re-render if necessary (React state update is usually synchronous in tests but wait is safer)
+        await waitFor(() => {
+            // Check for Student Names used in Student Leaderboard
+            expect(within(bestList).getByText('Rahul Kumar')).toBeInTheDocument();
+            expect(within(bestList).getByText('Anjali Singh')).toBeInTheDocument();
+        });
+
+        // Ensure class names are NOT present in the Best List
+        expect(within(bestList).queryByText('Grade 9A')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
# feat: Implement Dynamic Leaderboards (Classes vs Students)

## Description
This PR implements dynamic switching for the "Best Performing" and "Needing Support" leaderboards on the Analytics page. The content now adapts based on the context:
- **Global View**: Displays **Class rankings** (e.g., Grade 9A).
- **Subject View**: Displays **Student rankings** (e.g., Rahul Kumar).

Closes #250

## Changes
- Modified `frontend/src/pages/Analytics.jsx` to toggle between `GLOBAL_LEADERBOARD` and `STUDENT_LEADERBOARD` based on `selectedSubject`.
- Added unit tests in `frontend/src/pages/__tests__/Analytics.test.jsx` to verify the switching logic utilizing `data-testid`.

## Acceptance Criteria
- [x] "Best Performing" list shows **Classes** when "All Subjects" is selected.
- [x] "Best Performing" list shows **Students** when a specific subject is selected.
- [x] "Needing Support" list updates similarly based on context.
- [x] Unit tests passing for both scenarios.

## How to Test
1. Navigate to the **Analytics** page.
2. Select **"All Subjects"** in the dropdown → Verify the right-side lists show **Grades/Classes**.
3. Select a specific subject (e.g., **Mathematics**) → Verify the lists update to show **Student Names**.
4. Run tests: `npm test src/pages/__tests__/Analytics.test.jsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analytics now displays both global and subject-specific leaderboards, allowing users to compare performance across their entire class or drill down into individual subjects.
  * Leaderboards highlight top performers and students needing additional support.

* **Tests**
  * Added comprehensive test suite validating leaderboard functionality across global and subject-based views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->