### PR TITLE
refactor(backend): group schedule slots by subject (Nested Schema)

### DIFF
--- a/server/backend-api/app/api/routes/schedule.py
+++ b/server/backend-api/app/api/routes/schedule.py
@@ -1,12 +1,15 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from datetime import datetime
 from typing import List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 import os
 import pytz
+from uuid import uuid4
 
 from app.api.deps import get_current_teacher
 from app.services import schedule_service
+from app.db.mongo import db
+from app.db.subjects_repo import get_subjects_by_ids
 
 router = APIRouter(prefix="/schedule", tags=["schedule"])
 
@@ -25,6 +28,112 @@ class ClassPeriod(BaseModel):
 class TodayScheduleResponse(BaseModel):
     classes: List[ClassPeriod]
     current_day: str
+
+
+class AddSlotRequest(BaseModel):
+    subject_id: str
+    day: str
+    start_time: str
+    end_time: str
+    room: Optional[str] = None
+    slot: int = 0
+    # Optional tracked or other metadata, sticking to core Requirement
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def add_schedule_slot(
+    request: AddSlotRequest,
+    current: dict = Depends(get_current_teacher)
+):
+    teacher = current.get("teacher")
+    if not teacher:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Teacher profile not found"
+        )
+    teacher_id = str(teacher.get("userId"))
+    
+    # Verify subject exists via repo (optional but good practice)
+    # We need subject name to store in the schedule doc?
+    # If the schedule doc already exists, we might not strictly need it if we assume consistency.
+    # But if we create a NEW schedule doc, we should probably have it.
+    
+    # Check if schedule doc exists for this subject
+    schedule_doc = await db["schedules"].find_one({"subject_id": request.subject_id, "teacher_id": teacher_id})
+    
+    if not schedule_doc:
+        # Fetch subject details to populate subject_name
+        # Assuming subjects collection has name?
+        # Using get_subjects_by_ids([request.subject_id])
+        subjects = await get_subjects_by_ids([request.subject_id])
+        if not subjects:
+             raise HTTPException(status_code=404, detail="Subject not found")
+        subject_name = subjects[0].get("name")
+        
+        new_doc = {
+            "subject_id": request.subject_id,
+            "teacher_id": teacher_id,
+            "subject_name": subject_name,
+            "weekly_schedule": []
+        }
+        await db["schedules"].insert_one(new_doc)
+    
+    new_slot = {
+        "slot_id": str(uuid4()),
+        "day": request.day,
+        "slot": request.slot,
+        "start_time": request.start_time,
+        "end_time": request.end_time,
+        "room": request.room,
+        "tracked": True
+    }
+    
+    result = await db["schedules"].update_one(
+        {"subject_id": request.subject_id, "teacher_id": teacher_id},
+        {"$push": {"weekly_schedule": new_slot}}
+    )
+    
+    if result.modified_count == 0:
+        raise HTTPException(status_code=500, detail="Failed to add slot")
+        
+    return {"status": "success", "slot_id": new_slot["slot_id"]}
+
+
+@router.delete("/{slot_id}")
+async def delete_schedule_slot(
+    slot_id: str,
+    current: dict = Depends(get_current_teacher)
+):
+    teacher = current.get("teacher")
+    if not teacher:
+         raise HTTPException(status_code=404, detail="Teacher not found")
+    teacher_id = str(teacher.get("userId"))
+    
+    # We don't know the subject_id easily without querying.
+    # But we can query where "weekly_schedule.slot_id": slot_id
+    
+    result = await db["schedules"].update_one(
+        {"teacher_id": teacher_id, "weekly_schedule.slot_id": slot_id},
+        {"$pull": {"weekly_schedule": {"slot_id": slot_id}}}
+    )
+    
+    if result.modified_count == 0:
+         raise HTTPException(status_code=404, detail="Slot not found or not owned by teacher")
+         
+    return {"status": "success", "deleted_slot_id": slot_id}
+
+
+@router.get("", response_model=dict)
+async def get_schedule(current: dict = Depends(get_current_teacher)):
+    """
+    Get the full schedule for the teacher, in the format expected by the frontend.
+    """
+    teacher = current.get("teacher")
+    if not teacher:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Teacher not found"
+        )
+    teacher_id = str(teacher.get("userId"))
+    return await schedule_service.get_teacher_schedule_blob(teacher_id)
 
 
 @router.get("/today", response_model=TodayScheduleResponse)

--- a/server/backend-api/app/db/models.py
+++ b/server/backend-api/app/db/models.py
@@ -1,0 +1,25 @@
+from typing import List, Optional
+from pydantic import BaseModel, Field
+from uuid import uuid4
+
+class ScheduleSlot(BaseModel):
+    slot_id: str = Field(default_factory=lambda: str(uuid4()))
+    day: str
+    slot: int
+    start_time: str
+    end_time: str
+    room: Optional[str] = None
+    tracked: bool = True
+
+class SubjectScheduleDB(BaseModel):
+    """
+    Representation of the schedule document in MongoDB.
+    One document per subject per teacher.
+    """
+    subject_id: str
+    teacher_id: str
+    subject_name: Optional[str] = None
+    weekly_schedule: List[ScheduleSlot] = []
+
+    class Config:
+        populate_by_name = True

--- a/server/backend-api/app/main.py
+++ b/server/backend-api/app/main.py
@@ -21,6 +21,7 @@ from .core.config import APP_NAME, ORIGINS
 from app.services.attendance_daily import (
     ensure_indexes as ensure_attendance_daily_indexes,
 )
+from app.services.schedule_service import ensure_indexes as ensure_schedule_indexes
 from app.services.ml_client import ml_client
 from app.db.nonce_store import close_redis
 from app.core.scheduler import start_scheduler, shutdown_scheduler
@@ -61,6 +62,9 @@ async def lifespan(app: FastAPI):
     try:
         await ensure_attendance_daily_indexes()
         logger.info("attendance_daily indexes ensured")
+
+        await ensure_schedule_indexes()
+        logger.info("schedule indexes ensured")
 
         start_scheduler()
     except Exception as e:

--- a/server/backend-api/app/schemas/schedule.py
+++ b/server/backend-api/app/schemas/schedule.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List, Optional, Dict
 from datetime import date
+from uuid import uuid4
 
 
 class ClassMetadata(BaseModel):
@@ -9,6 +10,7 @@ class ClassMetadata(BaseModel):
     room: Optional[str] = None
     teacher_id: Optional[str] = None
     tracked: bool = True
+    slot_id: Optional[str] = None
 
 
 class Period(BaseModel):
@@ -48,3 +50,20 @@ class Schedule(BaseModel):
     holidays: Optional[List[Holiday]] = []
     exams: Optional[List[ExamOverride]] = []
     meta: Optional[Dict[str, str]] = None
+
+
+class ScheduleSlot(BaseModel):
+    slot_id: str = Field(default_factory=lambda: str(uuid4()))
+    day: str
+    slot: int
+    start_time: str
+    end_time: str
+    room: Optional[str] = None
+    tracked: bool = True
+
+
+class SubjectSchedule(BaseModel):
+    subject_id: str
+    teacher_id: str
+    subject_name: Optional[str] = None
+    weekly_schedule: List[ScheduleSlot] = []

--- a/server/backend-api/app/services/schedule_service.py
+++ b/server/backend-api/app/services/schedule_service.py
@@ -1,48 +1,69 @@
-from typing import List, Dict
+from typing import List, Dict, Optional
 from app.db.mongo import db
+from uuid import uuid4
+import pymongo
 
 COLLECTION_NAME = "schedules"
+
+async def ensure_indexes():
+    """
+    Ensure that we have a unique index on (teacher_id, subject_id).
+    This guarantees one schedule document per subject per teacher.
+    """
+    await db[COLLECTION_NAME].create_index(
+        [("teacher_id", pymongo.ASCENDING), ("subject_id", pymongo.ASCENDING)],
+        unique=True
+    )
+
+def generate_slot_id():
+    return str(uuid4())
 
 
 async def save_teacher_schedule(teacher_id: str, schedule_data: dict) -> None:
     """
-    Saves a teacher's schedule by converting the blob format into individual entries.
+    Saves a teacher's schedule by converting the blob format into Subject-based documents.
     Replaces existing entries for the teacher.
     """
     # Delete existing entries for this teacher to ensure clean slate
     await db[COLLECTION_NAME].delete_many({"teacher_id": teacher_id})
 
-    entries = []
+    subjects_map = {}
     timetable = schedule_data.get("timetable", []) or []
 
     for daily_item in timetable:
-        # daily_item is structured like { "day": "Monday", "periods": [...] }
-        # Need to handle potential dict or Pydantic object if passed from controller
         day = daily_item.get("day")
         if not day:
             continue
 
         periods = daily_item.get("periods", [])
         for p in periods:
-            # p is { "slot": 1, "start": "09:00", "end": "10:00", "metadata": {...} }
             metadata = p.get("metadata", {}) or {}
+            subject_id = metadata.get("subject_id")
+            
+            if not subject_id:
+                continue
 
-            entry = {
-                "teacher_id": teacher_id,
+            if subject_id not in subjects_map:
+                subjects_map[subject_id] = {
+                    "subject_id": subject_id,
+                    "teacher_id": teacher_id,
+                    "subject_name": metadata.get("subject_name"),
+                    "weekly_schedule": []
+                }
+            
+            slot_entry = {
+                "slot_id": generate_slot_id(),
                 "day": day,
                 "slot": p.get("slot", 0),
                 "start_time": p.get("start", ""),
                 "end_time": p.get("end", ""),
-                "subject_id": metadata.get("subject_id"),
-                "subject_name": metadata.get("subject_name"),
                 "room": metadata.get("room"),
-                # Optional fields
-                "tracked": metadata.get("tracked", True),
+                "tracked": metadata.get("tracked", True)
             }
-            entries.append(entry)
+            subjects_map[subject_id]["weekly_schedule"].append(slot_entry)
 
-    if entries:
-        await db[COLLECTION_NAME].insert_many(entries)
+    if subjects_map:
+        await db[COLLECTION_NAME].insert_many(list(subjects_map.values()))
 
 
 async def get_teacher_schedule_blob(teacher_id: str) -> dict:
@@ -50,10 +71,11 @@ async def get_teacher_schedule_blob(teacher_id: str) -> dict:
     Retrieves the schedule for a teacher and reconstructs the blob format
     expected by the frontend (and existing Schema).
     """
+    # 1. Fetch all subject-schedules for this teacher
     cursor = db[COLLECTION_NAME].find({"teacher_id": teacher_id})
-    entries = await cursor.to_list(length=None)
+    subject_docs = await cursor.to_list(length=None)
 
-    # Group by day
+    # 2. Flatten into the old "Period" list format, grouped by day
     days_map: Dict[str, List[dict]] = {
         "Monday": [],
         "Tuesday": [],
@@ -64,25 +86,31 @@ async def get_teacher_schedule_blob(teacher_id: str) -> dict:
         "Sunday": [],
     }
 
-    for entry in entries:
-        day = entry.get("day")
-        if day in days_map:
-            # Reconstruct Period object
-            period = {
-                "slot": entry.get("slot"),
-                "start": entry.get("start_time"),
-                "end": entry.get("end_time"),
-                "metadata": {
-                    "subject_id": entry.get("subject_id"),
-                    "subject_name": entry.get("subject_name"),
-                    "room": entry.get("room"),
-                    "tracked": entry.get("tracked", True),
-                    "teacher_id": teacher_id,
-                },
-            }
-            days_map[day].append(period)
+    for doc in subject_docs:
+        subject_id = doc.get("subject_id")
+        subject_name = doc.get("subject_name")
+        weekly_schedule = doc.get("weekly_schedule", [])
 
-    # Sort periods by slot or start time
+        for slot in weekly_schedule:
+            day = slot.get("day")
+            if day in days_map:
+                # Reconstruct Period object
+                period = {
+                    "slot": slot.get("slot", 0),
+                    "start": slot.get("start_time"),
+                    "end": slot.get("end_time"),
+                    "metadata": {
+                        "subject_id": subject_id,
+                        "subject_name": subject_name,
+                        "room": slot.get("room"),
+                        "tracked": slot.get("tracked", True),
+                        "teacher_id": teacher_id,
+                        "slot_id": slot.get("slot_id") 
+                    },
+                }
+                days_map[day].append(period)
+
+    # 3. Sort periods by slot or start time
     timetable = []
     for day_name, periods in days_map.items():
         if periods:
@@ -92,9 +120,9 @@ async def get_teacher_schedule_blob(teacher_id: str) -> dict:
     # Return full Schedule structure
     return {
         "timetable": timetable,
-        "recurring": None,  # Not migrated yet or stored separately
-        "holidays": [],  # Not migrated yet
-        "exams": [],  # Not migrated yet
+        "recurring": None,
+        "holidays": [],
+        "exams": [],
         "meta": {},
     }
 
@@ -103,13 +131,33 @@ async def get_today_schedule_entries(teacher_id: str, day_of_week: str) -> List[
     """
     Get raw schedule entries for a specific teacher and day.
     """
-    cursor = (
-        db[COLLECTION_NAME]
-        .find({"teacher_id": teacher_id, "day": day_of_week})
-        .sort("slot", 1)
-    )  # Sort by slot
-
-    return await cursor.to_list(length=None)
+    cursor = db[COLLECTION_NAME].find({"teacher_id": teacher_id, "weekly_schedule.day": day_of_week})
+    subject_docs = await cursor.to_list(length=None)
+    
+    flattened_entries = []
+    for doc in subject_docs:
+        weekly = doc.get("weekly_schedule", [])
+        # Filter for the specific day
+        day_slots = [s for s in weekly if s.get("day") == day_of_week]
+        
+        for s in day_slots:
+            entry = {
+                "teacher_id": teacher_id,
+                "day": s.get("day"),
+                "slot": s.get("slot", 0),
+                "start_time": s.get("start_time"),
+                "end_time": s.get("end_time"),
+                "subject_id": doc.get("subject_id"),
+                "subject_name": doc.get("subject_name"),
+                "room": s.get("room"),
+                "tracked": s.get("tracked", True),
+                "slot_id": s.get("slot_id")
+            }
+            flattened_entries.append(entry)
+            
+    # Sort
+    flattened_entries.sort(key=lambda x: x.get("slot", 0))
+    return flattened_entries
 
 
 async def get_student_schedule_for_day(
@@ -122,9 +170,31 @@ async def get_student_schedule_for_day(
         return []
 
     # Find schedules where subject_id is in the student's list AND day matches
-    query = {"subject_id": {"$in": subject_ids}, "day": day_of_week}
+    query = {"subject_id": {"$in": subject_ids}, "weekly_schedule.day": day_of_week}
 
-    cursor = db[COLLECTION_NAME].find(query).sort("start_time", 1)
+    cursor = db[COLLECTION_NAME].find(query)
+    subject_docs = await cursor.to_list(length=None)
 
-    return await cursor.to_list(length=None)
+    flattened_entries = []
+    for doc in subject_docs:
+        weekly = doc.get("weekly_schedule", [])
+        day_slots = [s for s in weekly if s.get("day") == day_of_week]
+        
+        for s in day_slots:
+            entry = {
+                "teacher_id": doc.get("teacher_id"),
+                "day": s.get("day"),
+                "slot": s.get("slot", 0),
+                "start_time": s.get("start_time"),
+                "end_time": s.get("end_time"),
+                "subject_id": doc.get("subject_id"),
+                "subject_name": doc.get("subject_name"),
+                "room": s.get("room"),
+                "tracked": s.get("tracked", True),
+                "slot_id": s.get("slot_id")
+            }
+            flattened_entries.append(entry)
+
+    flattened_entries.sort(key=lambda x: x.get("start_time", ""))
+    return flattened_entries
 

--- a/server/backend-api/scripts/migrate_schedules.py
+++ b/server/backend-api/scripts/migrate_schedules.py
@@ -1,0 +1,93 @@
+import asyncio
+import os
+import sys
+from uuid import uuid4
+from motor.motor_asyncio import AsyncIOMotorClient
+from dotenv import load_dotenv
+
+# Ensure we can import from app if needed, but standalone script is safer
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+load_dotenv()
+
+MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
+DB_NAME = os.getenv("MONGO_DB", "smart_attendance")
+
+async def migrate_schedule():
+    print(f"Connecting to {MONGO_URI} / {DB_NAME}")
+    client = AsyncIOMotorClient(MONGO_URI)
+    db = client[DB_NAME]
+    
+    collection = db["schedules"]
+    
+    # Fetch all documents
+    cursor = collection.find({})
+    to_migrate = []
+    
+    async for doc in cursor:
+        # Check if already migrated
+        if "weekly_schedule" in doc:
+            continue
+            
+        # Check if it's a flat document (has 'day', 'slot')
+        if "day" in doc and "slot" in doc:
+            to_migrate.append(doc)
+            
+    if not to_migrate:
+        print("No documents to migrate.")
+        return
+
+    print(f"Found {len(to_migrate)} flat documents to migrate.")
+    
+    # Group by (subject_id, teacher_id)
+    grouped = {} 
+    
+    deleted_ids = []
+    
+    for doc in to_migrate:
+        subject_id = doc.get("subject_id")
+        teacher_id = doc.get("teacher_id")
+        subject_name = doc.get("subject_name")
+        
+        if not subject_id or not teacher_id:
+            print(f"Skipping doc {doc.get('_id')} due to missing subject_id or teacher_id")
+            continue
+            
+        key = (str(subject_id), str(teacher_id))
+        
+        if key not in grouped:
+            grouped[key] = {
+                "subject_id": subject_id,
+                "teacher_id": teacher_id,
+                "subject_name": subject_name,
+                "weekly_schedule": []
+            }
+            
+        slot_entry = {
+            "slot_id": str(uuid4()),
+            "day": doc.get("day"),
+            "slot": doc.get("slot", 0),
+            "start_time": doc.get("start_time", ""),
+            "end_time": doc.get("end_time", ""),
+            "room": doc.get("room"),
+            "tracked": doc.get("tracked", True)
+        }
+        
+        grouped[key]["weekly_schedule"].append(slot_entry)
+        deleted_ids.append(doc["_id"])
+        
+    # Insert new documents
+    new_docs = list(grouped.values())
+    if new_docs:
+        print(f"Inserting {len(new_docs)} new subject-grouped documents...")
+        await collection.insert_many(new_docs)
+        
+    # Delete old documents
+    if deleted_ids:
+        print(f"Deleting {len(deleted_ids)} old flat documents...")
+        await collection.delete_many({"_id": {"$in": deleted_ids}})
+        
+    print("Migration complete.")
+
+if __name__ == "__main__":
+    asyncio.run(migrate_schedule())


### PR DESCRIPTION
# ♻️ Refactor: Group Schedule Slots by Subject (Nested Schema)

## Related Issue
Closes #350

## Description
This PR refactors the `schedules` collection schema to be **Subject-Centric**. Previously, every single class slot was a separate document, causing data fragmentation and making it difficult to query a full subject's schedule.

The new structure uses a **single document per subject per teacher**, which contains an array of all weekly slots (`weekly_schedule`). Each slot now has a unique UUID (`slot_id`) for precise updates and deletions.

## Key Changes

### 1. Database Schema Update
- Moved from a "Flat" structure (1 doc = 1 slot) to a "Nested" structure (1 doc = 1 subject).
- **New Schema Structure**:
  ```json
  {
    "_id": "...",
    "subject_id": "ObjectId('...')",
    "teacher_id": "ObjectId('...')",
    "subject_name": "Power Systems",
    "weekly_schedule": [
      {
        "slot_id": "uuid-v4...",
        "day": "Monday",
        "start_time": "09:00",
        "end_time": "10:00",
        "room": "G9",
        "tracked": true
      }
    ]
  }