### PR TITLE
fix: prevent full-page loader and persist sidebar during navigation (…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,11 +24,11 @@ const ForgotPassword = lazy(() => import("./pages/ForgotPassword"));
 const OAuthCallback = lazy(() => import("./pages/OAuthCallback"));
 
 // Student pages
-const StudentDashboard = lazy(() => import("./students/pages/StudentDashboard"));
-const StudentSubjects = lazy(() => import("./students/pages/StudentSubjects"));
-const StudentForecast = lazy(() => import("./students/pages/StudentForecast"));
-const StudentProfile = lazy(() => import("./students/pages/StudentProfile"));
-const MarkWithQR = lazy(() => import("./students/pages/MarkWithQR"));
+import StudentDashboard from "./students/pages/StudentDashboard";
+import StudentSubjects from "./students/pages/StudentSubjects";
+import StudentForecast from "./students/pages/StudentForecast";
+import StudentProfile from "./students/pages/StudentProfile";
+import MarkWithQR from "./students/pages/MarkWithQR";
 
 /**
  * Redirects the user to the appropriate home page based on their role.

--- a/frontend/src/students/pages/StudentSubjects.jsx
+++ b/frontend/src/students/pages/StudentSubjects.jsx
@@ -112,15 +112,6 @@ export default function StudentSubjects() {
     sub.code.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
-
-  if (loading) {
-     return (
-        <div className="min-h-screen bg-[var(--bg-primary)] flex items-center justify-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--primary)]"></div>
-        </div>
-     );
-  }
-
   return (
     <div className="min-h-screen bg-[var(--bg-primary)]">
       {/* 2. Sidebar (Desktop) */}
@@ -169,20 +160,23 @@ export default function StudentSubjects() {
             </button>
           </div>
           
-          {error && (
+          {loading ? (
+            <div className="flex items-center justify-center py-20">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--primary)]"></div>
+            </div>
+          ) : error ? (
             <div className="p-4 bg-[var(--danger)]/10 text-[var(--danger)] rounded-lg">
                {t(`subjects.errors.${error}`)}
             </div>
-          )}
-
-          {/* Subjects List */}
-          <div className="space-y-6">
-            {subjects.length === 0 ? (
-               <div className="p-8 text-center text-[var(--text-body)]/80 bg-[var(--bg-card)] rounded-2xl border border-[var(--border-color)]">
-                  {t('subjects.no_subjects')}
-               </div>
-            ) : (
-                subjects.map((sub) => (
+          ) : (
+            /* Subjects List */
+            <div className="space-y-6">
+              {subjects.length === 0 ? (
+                 <div className="p-8 text-center text-[var(--text-body)]/80 bg-[var(--bg-card)] rounded-2xl border border-[var(--border-color)]">
+                    {t('subjects.no_subjects')}
+                 </div>
+              ) : (
+                  subjects.map((sub) => (
               <div key={sub.id} className="bg-[var(--bg-card)] rounded-2xl p-6 border border-[var(--border-color)] shadow-sm hover:shadow-md transition-shadow">
                 
                 {/* Card Header */}
@@ -225,7 +219,8 @@ export default function StudentSubjects() {
               </div>
             ))
             )}
-          </div>
+            </div>
+          )}
 
         </div>
       </main>


### PR DESCRIPTION
## Description
Fixes #333 - Prevent Full-Page Loader & Persist Sidebar During Navigation

This PR resolves the issue where navigating between student pages caused the sidebar to disappear and a full-page loading spinner to show. The fix was implemented within the existing page structures without creating a new layout component.

### Changes Made:
- **`frontend/src/App.tsx`**: Replaced `lazy()` loading with direct imports for student pages. This prevents React Router's global `<Suspense>` boundary from catching the chunk-loading state and unmounting the sidebar to show the global `<LoadingFallback />`.
- **`frontend/src/students/pages/StudentSubjects.jsx`**: Refactored the page-level loading state. Instead of returning an early `if (loading)` full-page spinner, the component now always renders the `<StudentNavigation />` sidebar and conditionally renders the spinner only inside the `<main>` content area.

### Testing:
- Navigating between Home, Subjects, and other student pages now smoothly transitions the main content area while keeping the sidebar persistent.
- Verified that the build succeeds without any syntax errors.




https://github.com/user-attachments/assets/757b19d4-81c8-40d6-880b-9e6dcd9b5ee0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized application initialization for faster startup times.

* **User Interface**
  * Improved loading indicator on the Subjects page to display inline during data retrieval, providing better visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->