### PR TITLE
device binding workflow corrected

### DIFF
--- a/server/backend-api/app/schemas/auth.py
+++ b/server/backend-api/app/schemas/auth.py
@@ -66,6 +66,7 @@ class UserResponse(BaseModel):
     college_name: str
     token: str
     refresh_token: str | None = None
+    device_id: Optional[str] = None
 
 
 class RegisterResponse(BaseModel):


### PR DESCRIPTION
# 🔥 Pull Request Summary
This PR fixes a critical bug where the Device Binding OTP modal was failing to open when a user logged in from a new device. It also introduces a unified backend and frontend logout flow to track `last_logout_time`, which is required for the device binding cooldown logic.

---

# 🔗 Linked Issue
Closes # [Insert Issue Number Here]

---

# 📦 Type of Change
_Select all that apply:_

- [x] 🐛 Bug fix (non-breaking fix)
- [x] ✨ New feature (non-breaking feature)
- [ ] 💥 Breaking change
- [ ] 🎨 UI/UX improvement
- [x] ♻️ Code refactor (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests added or updated
- [ ] 📝 Documentation update

---

# 🛠 Changes Made
Key changes included in this PR:

- **Fixed `fetch` error handling in `Login.jsx`:** The catch block was incorrectly attempting to parse standard `fetch` errors as Axios errors (`err.response.data.detail`). It now correctly catches the thrown JS Error message (`err.message === "DEVICE_BINDING_REQUIRED"`) to trigger the modal.
- **Fixed Modal Prop Mismatch:** Corrected the prop passed to `<DeviceBindingOtpModal />` in `Login.jsx` from `email={email}` to `userEmail={email}` to match the component's expected props.
- **Unified Logout API:** Updated the backend `/auth/logout` endpoint to safely cast user IDs, prevent crashes on malformed tokens, and dynamically save `last_logout_time` for students while clearing active sessions for all users.
- **Frontend Logout Refactor:** Centralized the logout API call (`logout()`) inside `StudentNavigation.jsx` and `StudentProfile.jsx`. It now safely notifies the backend to clear the session before wiping local storage, ensuring the `device_uuid` remains intact for future logins.

---

# 🧪 How to Test
Steps for reviewers to verify the changes:

**Testing the OTP Modal Fix:**
1. Go to the **Login** page.
2. Clear your `device_uuid` from local storage (to simulate a new device).
3. Attempt to sign in with valid credentials.
4. Confirm that the **Device Verification OTP Modal** opens instantly.
5. Verify that clicking "Send OTP" successfully grabs the email from the login form and sends the request.

**Testing the Logout Flow:**
1. Log in as a Student.
2. Click the **Logout** button from either the Sidebar or the Profile page.
3. Check the MongoDB database for that user document and confirm that `current_active_session` is removed and `last_logout_time` is updated.
4. Confirm you are successfully redirected to the login screen and that `device_uuid` is still present in your local storage.

---

# 🎯 Expected Behaviour
- Users attempting to log in from an untrusted device should immediately see the OTP verification modal without the app failing silently.
- Logging out should cleanly remove active sessions and update the timestamp required for the device cooldown security feature, without wiping the trusted device ID from local storage.

---

# 📸 Screenshots / Proof
_Required for UI changes_

### Before
When 403 `DEVICE_BINDING_REQUIRED` was returned, the app logged an error to the console but remained stuck on the login screen.

### After
The OTP modal cleanly overlays the login screen immediately upon receiving the 403 error.

---

# ✔ Pre-Merge Checklist
Please confirm the following:

- [x] Code follows project standards
- [x] Linting and formatting checks pass
- [x] Changes tested locally
- [x] No unintended breaking changes
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated (if applicable)
- [x] Self-review completed

---

# 📝 Additional Notes
**Database Note:** The backend logout route uses the `$set` operator for `last_logout_time`. Mongoose/Motor will automatically create this field on existing student documents upon their first logout, so no manual database migrations are required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added device binding for enhanced account security—devices are automatically trusted on first login.
  * Implemented device verification that detects and prevents unauthorized access attempts from unrecognized devices within a one-hour window.

* **Improvements**
  * Enhanced error messaging for authentication and token-related issues.
  * Refined logout process with improved session management handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->