### PR TITLE
fix: only show 'all caught up' when scheduled classes are completed

### DIFF
--- a/frontend/src/students/pages/StudentDashboard.jsx
+++ b/frontend/src/students/pages/StudentDashboard.jsx
@@ -260,10 +260,12 @@ export default function StudentDashboard() {
                 )}
               </div>
 
-              {/* Empty State / End of List Decor */}
-              <div className="text-center mt-6">
-                <p className="text-xs text-[var(--text-body)]/70">{t("student_dashboard.schedule.all_caught_up")}</p>
-              </div>
+              {/* End of List — only show when there were actual classes and all are done */}
+              {schedule.length > 0 && schedule.every((item) => getStatus(item.start_time, item.end_time) === "Completed") && (
+                <div className="text-center mt-6">
+                  <p className="text-xs text-[var(--text-body)]/70">{t("student_dashboard.schedule.all_caught_up")}</p>
+                </div>
+              )}
             </div>
 
           </div>


### PR DESCRIPTION
## Problem

When no classes are scheduled for today, the student dashboard shows both:
- "No classes scheduled for today"
- "You're all caught up for today!"

The second message is redundant and confusing — it implies classes existed and were completed, when in reality none were scheduled.

## Fix

The "all caught up" message now only renders when:
1. There are actual scheduled classes (`schedule.length > 0`)
2. All of them have the `Completed` status

This uses the existing `getStatus()` helper to check each class's time-based status.

Fixes #481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the schedule completion indicator to display only when all schedule items are marked as completed, rather than appearing unconditionally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->