### PR TITLE
fix: conditionally render 'all caught up' empty state only when class…

### DIFF
--- a/frontend/src/students/pages/StudentDashboard.jsx
+++ b/frontend/src/students/pages/StudentDashboard.jsx
@@ -261,11 +261,18 @@ export default function StudentDashboard() {
               </div>
 
               {/* Empty State / End of List Decor */}
-              {schedule && schedule.length > 0 && (
-                <div className="text-center mt-6">
-                  <p className="text-xs text-[var(--text-body)]/70">{t("student_dashboard.schedule.all_caught_up")}</p>
-                </div>
-              )}
+              {schedule &&
+                schedule.length > 0 &&
+                schedule.every(
+                  (item) =>
+                    getStatus(item.start_time, item.end_time) === "Completed"
+                ) && (
+                  <div className="text-center mt-6">
+                    <p className="text-xs text-[var(--text-body)]/70">
+                      {t("student_dashboard.schedule.all_caught_up")}
+                    </p>
+                  </div>
+                )}
             </div>
 
           </div>


### PR DESCRIPTION
### Description
Fixes #481 
Fixes #485

This PR removes the redundant UI text "आज की सभी कक्षाएं हो गईं!" (All today's classes are done!) from conditionally rendering on days where a user has no classes scheduled to begin with. 

### Changes Made:
- **`StudentDashboard.jsx`**: Wrapped the bottom `div` containing `t("student_dashboard.schedule.all_caught_up")` in a conditional check (`{schedule && schedule.length > 0 && (...) }`).
- The message will now only gracefully render if the student actually has a loaded schedule in place for the day and they have completed it.

### Testing/Verification:
- Checked empty state days (like Sundays) and verified only the primary "No classes scheduled today" message was shown.
- Verified that "All caught up" correctly still renders dynamically on days with actual classes fully mapped out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "all caught up" message on the Student Dashboard to only display when appropriate, improving the clarity of the end-of-list state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->