### PR TITLE
Fix attendance threshold save

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -328,7 +328,11 @@ export default function Settings() {
         await loadProfile(serverProfile);
       }
       // optional: show toast success
-      toast.success("Settings saved successfully!");
+      toast.success(
+        t('settings.alerts.save_success', {
+          defaultValue: 'Settings saved successfully!',
+        }),
+      );
     } catch (err) {
       console.error("Save profile failed", err);
       setSaveError(err.message || t('settings.alerts.save_failed'));


### PR DESCRIPTION
# 🔥 Pull Request Summary
Fix attendance threshold values failing to save/update to backend.

---

# 🔗 Linked Issue
Closes #434

---

# 📦 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

# 🛠 Changes Made
- Fixed payload structure in `saveProfile()` — removed incorrect `profile:` wrapper so fields like `name`, `phone`, and `settings.thresholds` are sent at the top level as expected by the backend
- Added success toast notification when settings are saved
- Removed unused imports (`getNotificationPermissionState`, `showSystemNotification`)

---

# 🧪 Steps to Test
1. Go to `/settings` → **Thresholds** tab
2. Adjust the Warning and Critical sliders
3. Click **Save changes**
4. Verify success toast appears
5. Refresh page — values should persist (requires backend connected)

---

# 🎯 Expected Behaviour
Threshold values are correctly transmitted to the backend API and stored under `teachers.settings.thresholds` in the database.

---

# ✔ Checklist
- [x] Code follows project conventions
- [x] Tested locally
- [x] No breaking changes
- [x] Self-reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation message when settings are successfully saved.

* **Refactor**
  * Simplified settings data handling to streamline saves and removed unused notification code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->